### PR TITLE
feat(termination-grace-period): Add configurable termination grace period

### DIFF
--- a/helm/minio/Chart.yaml
+++ b/helm/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Multi-Cloud Object Storage
 name: minio
-version: 5.0.1
+version: 5.1.0
 appVersion: RELEASE.2022-10-24T18-35-07Z
 keywords:
   - minio

--- a/helm/minio/templates/deployment.yaml
+++ b/helm/minio/templates/deployment.yaml
@@ -170,6 +170,7 @@ spec:
           lifecycle:
             {{- toYaml .Values.lifecycle | nindent 12 }}
           {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
 {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/helm/minio/templates/gateway-deployment.yaml
+++ b/helm/minio/templates/gateway-deployment.yaml
@@ -167,6 +167,7 @@ spec:
           lifecycle:
             {{- toYaml .Values.lifecycle | nindent 12 }}
           {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
 {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -264,6 +264,9 @@ resources:
 ## Configure pod lifecyle
 lifecycle: {}
 
+## Configure Pod terminationGracePeriodSeconds, that should match the expected preStop lifecycle hook if any
+terminationGracePeriodSeconds: 30
+
 ## List of policies to be created after minio install
 ##
 ## In addition to default policies [readonly|readwrite|writeonly|consoleAdmin|diagnostics]


### PR DESCRIPTION
Recently we added a preStop hook to wait for open connection but this hook is being forcefully killed after the termination grace period (default 30s). We would like to increase that period to 5mins to let client the time to finish their connection.