### PR TITLE
Add a flag to disable the default env variables

### DIFF
--- a/helm/minio/Chart.yaml
+++ b/helm/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Multi-Cloud Object Storage
 name: minio
-version: 5.1.0
+version: 5.2.0
 appVersion: RELEASE.2022-10-24T18-35-07Z
 keywords:
   - minio

--- a/helm/minio/templates/deployment.yaml
+++ b/helm/minio/templates/deployment.yaml
@@ -101,6 +101,7 @@ spec:
             - name: {{ $scheme }}-console
               containerPort: {{ .Values.minioConsolePort }}
           env:
+            {{- if .Values.useDefaultRootCreds }}
             - name: MINIO_ROOT_USER
               valueFrom:
                 secretKeyRef:
@@ -111,6 +112,7 @@ spec:
                 secretKeyRef:
                   name: {{ template "minio.secretName" . }}
                   key: rootPassword
+            {{- end}}
             {{- if .Values.extraSecret }}
             - name: MINIO_CONFIG_ENV_FILE
               value: "/tmp/minio-config-env/config.env"

--- a/helm/minio/templates/gateway-deployment.yaml
+++ b/helm/minio/templates/gateway-deployment.yaml
@@ -102,6 +102,7 @@ spec:
             - name: {{ $scheme }}-console
               containerPort: {{ .Values.minioConsolePort }}
           env:
+            {{- if .Values.useDefaultRootCreds }}
             - name: MINIO_ROOT_USER
               valueFrom:
                 secretKeyRef:
@@ -112,6 +113,7 @@ spec:
                 secretKeyRef:
                   name: {{ template "minio.secretName" . }}
                   key: rootPassword
+            {{- end}}
             {{- if .Values.extraSecret }}
             - name: MINIO_CONFIG_ENV_FILE
               value: "/tmp/minio-config-env/config.env"

--- a/helm/minio/templates/statefulset.yaml
+++ b/helm/minio/templates/statefulset.yaml
@@ -139,6 +139,7 @@ spec:
             - name: {{ $scheme }}-console
               containerPort: {{ .Values.minioConsolePort }}
           env:
+            {{- if .Values.useDefaultRootCreds }}
             - name: MINIO_ROOT_USER
               valueFrom:
                 secretKeyRef:
@@ -149,6 +150,7 @@ spec:
                 secretKeyRef:
                   name: {{ template "minio.secretName" . }}
                   key: rootPassword
+            {{- end}}
             {{- if .Values.extraSecret }}
             - name: MINIO_CONFIG_ENV_FILE
               value: "/tmp/minio-config-env/config.env"

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -267,6 +267,9 @@ lifecycle: {}
 ## Configure Pod terminationGracePeriodSeconds, that should match the expected preStop lifecycle hook if any
 terminationGracePeriodSeconds: 30
 
+## Set the MINIO_ROOT env var to the default ones
+useDefaultRootCreds: true
+
 ## List of policies to be created after minio install
 ##
 ## In addition to default policies [readonly|readwrite|writeonly|consoleAdmin|diagnostics]


### PR DESCRIPTION
As we inject the variables through the extraEnv variables we need a way to disable the default one so we don't get the same variable twice (which break the helm upgrade).