### PR TITLE
Fix/internal event queue full 3

### DIFF
--- a/cmd/event-notification.go
+++ b/cmd/event-notification.go
@@ -19,7 +19,6 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -219,7 +218,7 @@ func (evnot *EventNotifier) Send(args eventArgs) {
 	default:
 		// A new goroutine is created for each notification job, eventsQueue is
 		// drained quickly and is not expected to be filled with any scenario.
-		logger.LogIf(context.Background(), errors.New("internal events queue unexpectedly full"))
+		logger.LogIf(context.Background(), fmt.Errorf("internal events queue unexpectedly full, eventArgs: %+v", args))
 	}
 }
 

--- a/internal/event/targetlist.go
+++ b/internal/event/targetlist.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	// The maximum allowed number of concurrent Send() calls to all configured notifications targets
-	maxConcurrentTargetSendCalls = 100000
+	maxConcurrentTargetSendCalls = 20000
 )
 
 // Target - event target interface


### PR DESCRIPTION
tl;dr; those events are not used in gateway mode. The monitoring subsystem listen on them but are not used for the metrics we use (`minio_s3_requests_`) because this use another global channel to update the metrics.